### PR TITLE
Add Firefox extension for `.vertical-align` baseline-middle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 <!-- Add unreleased changes here -->
+- Fix `vertical-align` class to properly align text in Firefox
 
 ## [1.0.1] - 2022-08-04
 

--- a/app/assets/stylesheets/redis_ui_rails/application.css
+++ b/app/assets/stylesheets/redis_ui_rails/application.css
@@ -22,5 +22,6 @@
 }
 
 .vertical-align {
-  vertical-align: -webkit-baseline-middle
+  vertical-align: -webkit-baseline-middle;
+  vertical-align: -moz-middle-with-baseline;
 }


### PR DESCRIPTION
# Problem

Tags with the `vertical-align` class have misaligned text in Firefox.

<img width="400" alt="before" src="https://user-images.githubusercontent.com/593192/182960104-910b9f3c-ab82-4258-8f3b-6e31d8588148.png">


# Solution

`vertical-align: -webkit-baseline-middle` is WebKit/Blink specific. Firefox/Gecko has its own extension
for this value using `vertical-align: -moz-middle-with-baseline`.  Use both in the CSS and the user agent will apply the value it understands.

<img width="400" alt="after" src="https://user-images.githubusercontent.com/593192/182960072-df068e7c-85e2-47d2-9a65-a336ada464bb.png">

# Checklist

<!--
  Consider these before making the pull request. This section may be
  included in the final pull request description or cleared.
-->

* [ ] Is there test coverage of the new code?
* [x] Is there a CHANGELOG entry for the new changes?
* [x] Is the PR solving a single problem?
* [x] Does the PR description contain a problem statement?
* [x] Does the PR description explain the solution?
* [x] Are the commits atomic?
* [x] Are the commit messages serving as a clear record of why?
