### PR TITLE
[feat] support more Redis data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<!-- Add unreleased changes here -->
+
+## [1.2.0] - 2022-09-30
+
 - Added ability to find-and-delete more than just Redis "string" keys.
 
 ## [1.1.0] - 2022-09-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-<!-- Add unreleased changes here -->
+- Added ability to find-and-delete more than just Redis "string" keys.
 
 ## [1.1.0] - 2022-09-16
 

--- a/app/controllers/redis_ui_rails/key_searches_controller.rb
+++ b/app/controllers/redis_ui_rails/key_searches_controller.rb
@@ -7,7 +7,12 @@ module RedisUiRails
     def create
       @instance = Instance.find(params[:id])
       key = params[:key]
-      value = @instance.get(params[:key])
+
+      value = case @instance.type(key)
+      when "none" then nil
+      else
+        "found"
+      end
 
       if value.nil?
         flash[:warning] = "No key '#{key}' found in Redis instance '#{@instance.id}'"
@@ -20,12 +25,15 @@ module RedisUiRails
     def show
       @instance = Instance.find(params[:id])
       @key = params[:key]
-      @value = @instance.get(params[:key])
+      @value = RedisValue.find(@key, instance: @instance)
 
       if @value.nil?
         flash[:warning] = "No key '#{params[:key]}' found in Redis instance '#{@instance.id}'"
         render :new
       end
+    rescue => e
+      flash[:error] = e.message
+      render :new
     end
   end
 end

--- a/app/views/redis_ui_rails/key_searches/show.html.erb
+++ b/app/views/redis_ui_rails/key_searches/show.html.erb
@@ -16,7 +16,7 @@
     <b class="has-text-weight-bold">Key:</b> <%= @key %>
   </div>
   <div>
-    <b class="has-text-weight-bold">Value:</b> <%= @value %>
+    <b class="has-text-weight-bold">Value (long lists may be truncated):</b> <%= @value %>
   </div>
   <br>
   <%= link_to new_instance_key_search_path(@instance.id) do %>

--- a/lib/redis_ui_rails.rb
+++ b/lib/redis_ui_rails.rb
@@ -8,6 +8,8 @@ require "redis"
 require "redis_ui_rails/version"
 require "redis_ui_rails/errors"
 require "redis_ui_rails/config_redis_instance"
+require "redis_ui_rails/instance"
+require "redis_ui_rails/redis_value"
 require "redis_ui_rails/config"
 require "redis_ui_rails/engine"
 

--- a/lib/redis_ui_rails/errors.rb
+++ b/lib/redis_ui_rails/errors.rb
@@ -1,3 +1,7 @@
 module RedisUiRails
   class InstanceMissing < StandardError; end
+
+  class RedisValueMissing < StandardError; end
+
+  class UnsupportedValueType < StandardError; end
 end

--- a/lib/redis_ui_rails/instance.rb
+++ b/lib/redis_ui_rails/instance.rb
@@ -19,7 +19,19 @@ module RedisUiRails
     end
 
     delegate :name, :id, :url, :resource_links, to: :config_redis_instance
-    delegate :randomkey, :info, :get, :set, :del, to: :redis
+    delegate(
+      :randomkey,
+      :info,
+      :get,
+      :set,
+      :type,
+      :hgetall,
+      :llen,
+      :lrange,
+      :srandmember,
+      :del,
+      to: :redis
+    )
 
     private
 

--- a/lib/redis_ui_rails/redis_value.rb
+++ b/lib/redis_ui_rails/redis_value.rb
@@ -1,0 +1,25 @@
+module RedisUiRails
+  class RedisValue
+    MAX_RETRIEVED_LIST_LENGTH = 10
+
+    class << self
+      def find(key, instance:)
+        case instance.type(key)
+        when "string"
+          instance.get(key)
+        when "hash"
+          instance.hgetall(key)
+        when "list"
+          max = [instance.llen(key), MAX_RETRIEVED_LIST_LENGTH].min
+          instance.lrange(key, 0, max)
+        when "set"
+          instance.srandmember(key, MAX_RETRIEVED_LIST_LENGTH)
+        when "none"
+          raise RedisValueMissing.new("Unable to find key '#{key}' in Redis instance '#{name}'")
+        else
+          raise UnsupportedValueType.new("Unsupported Redis key value type of '#{instance.type(key)}'")
+        end
+      end
+    end
+  end
+end

--- a/lib/redis_ui_rails/version.rb
+++ b/lib/redis_ui_rails/version.rb
@@ -1,3 +1,3 @@
 module RedisUiRails
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end

--- a/spec/redis_ui_rails/redis_value_spec.rb
+++ b/spec/redis_ui_rails/redis_value_spec.rb
@@ -1,0 +1,108 @@
+require "spec_helper"
+
+RSpec.describe RedisUiRails::RedisValue do
+  describe "#find" do
+    let(:mock_redis) { MockRedis.new }
+    let(:config_redis_instance) { RedisUiRails::ConfigRedisInstance.new(name: "dummy") }
+    let(:instance) { RedisUiRails::Instance.new(config_redis_instance) }
+    let(:result) { find! }
+
+    def find!
+      described_class.find(key, instance: instance)
+    end
+
+    before do
+      allow(Redis).to receive(:new).and_return(mock_redis)
+    end
+
+    context "given a string key" do
+      let(:key) { "key" }
+      let(:value) { "val" }
+
+      before(:each) { mock_redis.set(key, value) }
+
+      it "returns the value" do
+        expect(result).to eq(value)
+      end
+    end
+
+    context "given a hash key" do
+      let(:key) { "key" }
+      let(:value) { {"value" => "1"} }
+
+      before(:each) { mock_redis.hset(key, value) }
+
+      it "returns the value" do
+        expect(result).to eq(value)
+      end
+    end
+
+    context "given a list key" do
+      let(:key) { "key" }
+      let(:value) { "value" }
+
+      before(:each) { mock_redis.lpush(key, value) }
+
+      it "returns the value" do
+        expect(result).to eq([value])
+      end
+    end
+
+    context "given a set key" do
+      let(:key) { "key" }
+      let(:value) { "value" }
+
+      before(:each) { mock_redis.sadd(key, value) }
+
+      it "returns the value" do
+        expect(result).to eq([value])
+      end
+    end
+
+    context "given no value" do
+      let(:key) { "missing" }
+
+      it "raises an error" do
+        expect { find! }.to raise_error(RedisUiRails::RedisValueMissing)
+      end
+    end
+
+    context "given an unsupported value type" do
+      let(:key) { "unsupported" }
+
+      before(:each) { allow(instance).to receive(:type).and_return("other") }
+
+      it "raises an error" do
+        expect { find! }.to raise_error(RedisUiRails::UnsupportedValueType)
+      end
+    end
+
+    describe "trunaction of values" do
+      context "given a very long list" do
+        let(:key) { "key" }
+        let(:large_size) { 100 }
+
+        before(:each) do
+          large_size.times { |i| mock_redis.lpush(key, i) }
+        end
+
+        it "truncates the returned list" do
+          expect(result.size).to be < large_size
+        end
+      end
+
+      context "given a very long set" do
+        let(:key) { "key" }
+        let(:large_size) { 100 }
+
+        before(:each) do
+          large_size.times { |i| mock_redis.sadd(key, i) }
+        end
+
+        it "truncates the returned list" do
+          expect(result.size).to be < large_size
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In Redis 6, key data types were introduces. This means that `redis.get` now only works for strings. Sidekiq uses other data types, like lists & hashes, to keep track of more complex data. This should allow us to inspect most if not all of those keys.
